### PR TITLE
fix: duplicated avatar while creating room

### DIFF
--- a/Communication/Packets/Incoming/Rooms/Engine/GetRoomEntryDataEvent.cs
+++ b/Communication/Packets/Incoming/Rooms/Engine/GetRoomEntryDataEvent.cs
@@ -23,7 +23,7 @@ internal class GetRoomEntryDataEvent : IPacketEvent
         var room = session.GetHabbo().CurrentRoom;
         if (room == null)
             return Task.CompletedTask;
-        if (!room.GetRoomUserManager().AddAvatarToRoom(session))
+        if (!room.GetRoomUserManager().TryAddAvatarToRoom(session))
         {
             room.GetRoomUserManager().RemoveUserFromRoom(session, false);
             return Task.CompletedTask; //TODO: Remove?

--- a/HabboHotel/Rooms/RoomUserManager.cs
+++ b/HabboHotel/Rooms/RoomUserManager.cs
@@ -128,6 +128,9 @@ public class RoomUserManager
             return false;
         if (session.GetHabbo().CurrentRoom == null)
             return false;
+        if (_users.Values.Any(x => x.HabboId == session.GetHabbo().Id))
+            return false;
+        
         var user = new RoomUser(session.GetHabbo().Id, _room.RoomId, _primaryPrivateUserId++, _room);
         if (user == null || user.GetClient() == null)
             return false;

--- a/HabboHotel/Rooms/RoomUserManager.cs
+++ b/HabboHotel/Rooms/RoomUserManager.cs
@@ -128,6 +128,11 @@ public class RoomUserManager
             return false;
         if (session.GetHabbo().CurrentRoom == null)
             return false;
+        
+        // TODO: After room user manager and room joiner refractored, this should be removed or moved from here...
+        // GetRoomEntryDataEvent tried to enter in the room twice or three times at same time. Every time new room user is created.
+        // (check https://github.com/80O/PlusEMU/issues/44#issuecomment-1109187914 for more info)
+        // Thanks for Damien#7670
         if (_users.Values.Any(x => x.HabboId == session.GetHabbo().Id))
             return false;
         

--- a/HabboHotel/Rooms/RoomUserManager.cs
+++ b/HabboHotel/Rooms/RoomUserManager.cs
@@ -120,12 +120,8 @@ public class RoomUserManager
 
     public RoomUser GetUserForSquare(int x, int y) => _room.GetGameMap().GetRoomUsers(new Point(x, y)).FirstOrDefault();
 
-    public bool AddAvatarToRoom(GameClient session)
+    public bool TryAddAvatarToRoom(GameClient session)
     {
-        if (_room == null)
-            return false;
-        if (session == null)
-            return false;
         if (session.GetHabbo().CurrentRoom == null)
             return false;
         
@@ -137,8 +133,9 @@ public class RoomUserManager
             return false;
         
         var user = new RoomUser(session.GetHabbo().Id, _room.RoomId, _primaryPrivateUserId++, _room);
-        if (user == null || user.GetClient() == null)
+        if (user.GetClient() == null)
             return false;
+        
         user.UserId = session.GetHabbo().Id;
         session.GetHabbo().TentId = 0;
         var personalId = _secondaryPrivateUserId++;
@@ -146,11 +143,14 @@ public class RoomUserManager
         session.GetHabbo().CurrentRoomId = _room.RoomId;
         if (!_users.TryAdd(personalId, user))
             return false;
+        
         var model = _room.GetGameMap().Model;
         if (model == null)
             return false;
+        
         if (!_room.PetMorphsAllowed && session.GetHabbo().PetId != 0)
             session.GetHabbo().PetId = 0;
+        
         if (!session.GetHabbo().IsTeleporting && !session.GetHabbo().IsHopping)
         {
             if (!model.DoorIsValid())
@@ -222,6 +222,7 @@ public class RoomUserManager
         user.UpdateNeeded = true;
         if (session.GetHabbo().GetPermissions().HasRight("mod_tool") && !session.GetHabbo().DisableForcedEffects)
             session.GetHabbo().Effects().ApplyEffect(102);
+        
         foreach (var bot in _bots.Values.ToList())
         {
             if (bot == null || bot.BotAi == null)

--- a/HabboHotel/Rooms/RoomUserManager.cs
+++ b/HabboHotel/Rooms/RoomUserManager.cs
@@ -125,10 +125,6 @@ public class RoomUserManager
         if (session.GetHabbo().CurrentRoom == null)
             return false;
         
-        // TODO: After room user manager and room joiner refractored, this should be removed or moved from here...
-        // GetRoomEntryDataEvent tried to enter in the room twice or three times at same time. Every time new room user is created.
-        // (check https://github.com/80O/PlusEMU/issues/44#issuecomment-1109187914 for more info)
-        // Thanks for Damien#7670
         if (_users.Values.Any(x => x.HabboId == session.GetHabbo().Id))
             return false;
         


### PR DESCRIPTION
Fix #44 

This is workaround, still need see why joining room packet is handled twice (or 3 times) but this solve duplicated avatars issue for now...

Thanks for @DamienJolly