### PR TITLE
Remove Socket.DontFragment

### DIFF
--- a/HabboHotel/GameClients/TcpSessionProxy.cs
+++ b/HabboHotel/GameClients/TcpSessionProxy.cs
@@ -26,7 +26,6 @@ namespace Plus.HabboHotel.GameClients
 
         protected override void OnConnected()
         {
-            Socket.DontFragment = true;
             base.OnConnected();
         }
 

--- a/HabboHotel/GameClients/WsSessionProxy.cs
+++ b/HabboHotel/GameClients/WsSessionProxy.cs
@@ -19,7 +19,6 @@ namespace Plus.HabboHotel.GameClients
 
         protected override void OnConnected()
         {
-            Socket.DontFragment = true;
             base.OnConnected();
         }
 


### PR DESCRIPTION
The **DontFragment** property has no effect on a TCP socket, [see this](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.dontfragment?view=net-6.0#remarks).
I'm also proposing to remove it because this operation is not supported on macOS (throws [SocketException](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socketexception?view=net-6.0)).

I didn't see any changes after removing this, but feel free to make further testing before merging.