### PR TITLE
Solved issue #135

### DIFF
--- a/HabboHotel/Rooms/Games/GameItemHandler.cs
+++ b/HabboHotel/Rooms/Games/GameItemHandler.cs
@@ -84,28 +84,18 @@ public class GameItemHandler
 
     public void OnTeleportRoomUserEnter(RoomUser user, Item item)
     {
-        var items = _banzaiTeleports.Values.Where(p => p.Id != item.Id);
-        var count = items.Count();
-        var countId = Random.Shared.Next(0, count);
-        var countAmount = 0;
-        if (count == 0)
+        if (_banzaiTeleports.Count <= 1) 
             return;
-        foreach (var i in items.ToList())
-        {
-            if (i == null)
-                continue;
-            if (countAmount == countId)
-            {
-                i.ExtraData = "1";
-                i.UpdateNeeded = true;
-                _room.GetGameMap().TeleportToItem(user, item);
-                i.ExtraData = "1";
-                i.UpdateNeeded = true;
-                i.UpdateState();
-                i.UpdateState();
-            }
-            countAmount++;
-        }
+
+        var banzais = _banzaiTeleports.Values.Where(_banzai => _banzai.Id != item.Id).ToArray();
+        var banzai = banzais[Random.Shared.Next(0, banzais.Length)];
+
+        banzai.ExtraData = "1";
+        banzai.UpdateNeeded = true;
+        banzai.UpdateState();
+
+        _room.GetGameMap().TeleportToItem(user, banzai);
+
     }
 
     public void Dispose()


### PR DESCRIPTION
Fixed BattleBanzai Tile interactor as indicated in issue #135 .
The user is teleported to another tile now, and if there is just one tile in the room then nothing happen.

**GIF of working behaviour**
![a602d86c6b0a232e87083f2b159c64e4](https://user-images.githubusercontent.com/46633727/205437510-29c65151-d8ec-4eed-8fe9-e0f075cb6668.gif)
