### PR TITLE
Replace setx command and use PowerShell

### DIFF
--- a/Plus Emulator.csproj
+++ b/Plus Emulator.csproj
@@ -66,7 +66,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(OS)' == 'Windows_NT' ">
-	  <Exec Command="setx PLUS_EMULATOR_HOME $([System.IO.Path]::GetFullPath('$(OutDir)'))" />
+		<Exec Command="powershell -Command '[Environment]::SetEnvironmentVariable(&quot;PLUS_EMULATOR_HOME&quot;, &quot;$([System.IO.Path]::GetFullPath('$(OutDir)'))&quot;, [System.EnvironmentVariableTarget]::Machine)'" />
 	</Target>
 	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
 		<Exec Command="echo Configuration: $(Configuration)&#xD;&#xA;echo DevEnvDir: $(DevEnvDir)&#xD;&#xA;echo OutDir: $(OutDir)&#xD;&#xA;echo ProjectDir: $(ProjectDir)&#xD;&#xA;echo VisualStudioVersion: $(VisualStudioVersion)&#xD;&#xA;echo AssemblySearchPaths: $(AssemblySearchPaths)&#xD;&#xA;echo AssemblyName: $(AssemblyName)&#xD;&#xA;echo BaseIntermediateOutputPath: $(BaseIntermediateOutputPath)&#xD;&#xA;echo CscToolPath: $(CscToolPath)" />


### PR DESCRIPTION
Started getting the following error on build;
`MSB3073 - The command "setx PLUS_EMULATOR_HOME D:\VS Repos\PlusEMU\bin\Debug\net7.0\" exited with code 1.`

I explored that the error in the PostBuild event could be due to the fact that `setx` command is attempting to create a new environment variable with a value that already exists. I tried to mitigate this issue by adding the `/M` flag to the `setx` command, which modifies the system environment variable instead of the user environment variable. I also added the `/F` flag, which will force the overwrite of the existing variable value.

But it appeared that the `setx` command still results in an error. So I used a different approach using PowerShell to set the environment variable.

Replacing the `<Exec Command>` line in the `<Target Name="PostBuild">` section with the following line:

`<Exec Command="powershell -Command '[Environment]::SetEnvironmentVariable(&quot;PLUS_EMULATOR_HOME&quot;, &quot;$([System.IO.Path]::GetFullPath('$(OutDir)'))&quot;, [System.EnvironmentVariableTarget]::Machine)'" />`
This command will use PowerShell to set the PLUS_EMULATOR_HOME environment variable at the machine level.

Now have a successful build, works as intended